### PR TITLE
[Chapter - 14]Followers and Following

### DIFF
--- a/app/assets/javascripts/relationships.coffee
+++ b/app/assets/javascripts/relationships.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -367,3 +367,46 @@ span.picture input {
   color: #c8102e;
   text-decoration: none;
 }
+
+.stats {
+  overflow: auto;
+  margin-top: 0;
+  padding: 0;
+  a:hover {
+    text-decoration: none;
+    color: #c8102e;
+  }
+  strong {
+    display: block;
+  }
+}
+
+.following {
+  color: gray;
+  padding-left: 0;
+  padding-right: 30px;
+  border: 0;
+
+  float: left;
+}
+.followers {
+  color: gray;
+  padding-left: 30px;
+  border-left: 1px solid $gray-lighter;
+  float: left;
+}
+
+.user_avatars {
+  overflow: auto;
+  margin-top: 10px;
+  .gravatar {
+    margin: 1px 1px;
+  }
+  a {
+    padding: 0;
+  }
+}
+
+.users.follow {
+  padding: 0;
+}

--- a/app/assets/stylesheets/relationships.scss
+++ b/app/assets/stylesheets/relationships.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Relationships controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,0 +1,16 @@
+class RelationshipsController < ApplicationController
+    before_action :logged_in_user
+  
+    def create
+      user = User.find(params[:followed_id])
+      current_user.follow(user)
+      redirect_to user
+    end
+  
+    def destroy
+      user = Relationship.find(params[:id]).followed
+      current_user.unfollow(user)
+      redirect_to user
+    end
+end
+  

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :logged_in_user, only: [:index, :edit, :update, :destroy]
+  before_action :logged_in_user, only: [:index, :edit, :update, :destroy, :following, :followers]
   before_action :correct_user, only: [:edit, :update]
   before_action :admin_user, only: :destroy
   def show
@@ -45,6 +45,21 @@ class UsersController < ApplicationController
     flash[:success] = "User Deleted Successfully"
     redirect_to users_url
   end
+
+  def following
+    @title = "Following"
+    @user  = User.find(params[:id])
+    @users = @user.following.paginate(page: params[:page])
+    render 'show_follow'
+  end
+
+  def followers
+    @title = "Followers"
+    @user  = User.find(params[:id])
+    @users = @user.followers.paginate(page: params[:page])
+    render 'show_follow'
+  end
+
 
   private
   

--- a/app/helpers/relationships_helper.rb
+++ b/app/helpers/relationships_helper.rb
@@ -1,0 +1,2 @@
+module RelationshipsHelper
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,4 @@
+class Relationship < ApplicationRecord
+    belongs_to :follower, class_name: "User"
+    belongs_to :followed, class_name: "User"
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,4 +1,6 @@
 class Relationship < ApplicationRecord
     belongs_to :follower, class_name: "User"
     belongs_to :followed, class_name: "User"
+    validates :follower_id, presence: true
+    validates :followed_id, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,8 @@
 class User < ApplicationRecord
     has_many :microposts, dependent: :destroy
+    has_many :active_relationships, class_name: "Relationship",
+                                    foreign_key: "follower_id",
+                                    dependent: :destroy
     attr_accessor :remember_token, :activation_token, :reset_token
     before_save :downcase_email
     before_create :create_activation_digest

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,7 +70,10 @@ class User < ApplicationRecord
     end
 
     def feed
-        Micropost.where("user_id IN (?) OR user_id = ?", following_ids, id)
+        following_ids = "SELECT followed_id FROM relationships
+                         WHERE follower_id = :user_id"
+        Micropost.where("user_id IN (#{following_ids})
+                         OR user_id = :user_id", user_id: id)
     end
 
     def follow(other_user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,11 @@ class User < ApplicationRecord
     has_many :active_relationships, class_name: "Relationship",
                                     foreign_key: "follower_id",
                                     dependent: :destroy
+    has_many :passive_relationships, class_name: "Relationship",
+                                     foreign_key: "followed_id",
+                                     dependent: :destroy
+    has_many :following, through: :active_relationships, source: :followed
+    has_many :followers, through: :passive_relationships, source: :follower
     attr_accessor :remember_token, :activation_token, :reset_token
     before_save :downcase_email
     before_create :create_activation_digest
@@ -66,6 +71,18 @@ class User < ApplicationRecord
 
     def feed
         Micropost.where("user_id = ?", id)
+    end
+
+    def follow(other_user)
+        following << other_user
+    end
+
+    def unfollow(other_user)
+        active_relationships.find_by(followed_id: other_user.id).destroy
+    end
+
+    def following?(other_user)
+        following.include?(other_user)
     end
 
     private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,7 +70,7 @@ class User < ApplicationRecord
     end
 
     def feed
-        Micropost.where("user_id = ?", id)
+        Micropost.where("user_id IN (?) OR user_id = ?", following_ids, id)
     end
 
     def follow(other_user)

--- a/app/views/shared/_stats.html.erb
+++ b/app/views/shared/_stats.html.erb
@@ -1,0 +1,15 @@
+<% @user ||= current_user %>
+<div class="stats">
+  <a href="<%= following_user_path(@user) %>" class= "following">
+    <strong id="following" class="stat">
+      <%= @user.following.count %>
+    </strong>
+    following
+  </a>
+  <a href="<%= followers_user_path(@user) %>" class = "followers">
+    <strong id="followers" class="stat">
+      <%= @user.followers.count %>
+    </strong>
+    followers
+  </a>
+</div>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -5,6 +5,9 @@
       <section class="user_info">
         <%= render 'shared/user_info' %>
       </section>
+      <section class="user_info">
+        <%= render 'shared/stats' %>
+      </section>
       <section class="micropost_form">
         <%= render 'shared/micropost_form' %>
       </section>

--- a/app/views/users/_follow.html.erb
+++ b/app/views/users/_follow.html.erb
@@ -1,0 +1,5 @@
+<%= form_for(current_user.active_relationships.build) do |f| %>
+    <div><%= hidden_field_tag :followed_id, @user.id %></div>
+    <%= f.submit "Follow", class: "btn btn-success" %>
+<% end %>
+  

--- a/app/views/users/_follow_form.html.erb
+++ b/app/views/users/_follow_form.html.erb
@@ -1,0 +1,9 @@
+<% unless current_user?(@user) %>
+  <div id="follow_form">
+  <% if current_user.following?(@user) %>
+    <%= render 'unfollow' %>
+  <% else %>
+    <%= render 'follow' %>
+  <% end %>
+  </div>
+<% end %>

--- a/app/views/users/_unfollow.html.erb
+++ b/app/views/users/_unfollow.html.erb
@@ -1,0 +1,4 @@
+<%= form_for(current_user.active_relationships.find_by(followed_id: @user.id),
+             html: { method: :delete }) do |f| %>
+  <%= f.submit "Unfollow", class: "btn red-button" %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,8 +7,12 @@
         <%= @user.name %>
       </h1>
     </section>
+    <section class="stats">
+      <%= render 'shared/stats' %>
+    </section>
   </aside>
   <div class="col-md-6">
+    <%= render 'follow_form' if logged_in? %>
     <% if @user.microposts.any? %>
       <h3>Microposts (<%= @user.microposts.count %>)</h3>
       <ol class="microposts">

--- a/app/views/users/show_follow.html.erb
+++ b/app/views/users/show_follow.html.erb
@@ -1,0 +1,30 @@
+<% provide(:title, @title) %>
+<div class="row">
+  <aside class="col-md-4">
+    <section class="user_info">
+      <%= gravatar_for @user %>
+      <h1><%= @user.name %></h1>
+      <span><%= link_to "view profile", @user, class: "view-my-profile" %></span>
+      <span><b>Microposts:</b> <%= @user.microposts.count %></span>
+    </section>
+    <section class="stats">
+      <%= render 'shared/stats' %>
+      <% if @users.any? %>
+        <div class="user_avatars">
+          <% @users.each do |user| %>
+            <%= link_to gravatar_for(user, size: 30), user %>
+          <% end %>
+        </div>
+      <% end %>
+    </section>
+  </aside>
+  <div class="col-md-8">
+    <h3><%= @title %></h3>
+    <% if @users.any? %>
+      <ul class="users follow">
+        <%= render @users %>
+      </ul>
+      <%= will_paginate %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,9 +13,14 @@ Rails.application.routes.draw do
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'
-  resources :users
+  resources :users do
+    member do
+      get :following, :followers
+    end
+  end
   resources :account_activations, only: [:edit]
   resources :password_resets,     only: [:new, :create, :edit, :update]
   resources :microposts,          only: [:create, :destroy]
+  resources :relationships,       only: [:create, :destroy]
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20240313064236_create_relationships.rb
+++ b/db/migrate/20240313064236_create_relationships.rb
@@ -1,0 +1,13 @@
+class CreateRelationships < ActiveRecord::Migration[5.1]
+  def change
+    create_table :relationships do |t|
+      t.integer :follower_id
+      t.integer :followed_id
+
+      t.timestamps
+    end
+    add_index :relationships, :follower_id
+    add_index :relationships, :followed_id
+    add_index :relationships, [:follower_id, :followed_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20240311081254) do
+ActiveRecord::Schema.define(version: 20240313064236) do
 
   create_table "microposts", force: :cascade do |t|
     t.text "content"
@@ -20,6 +20,16 @@ ActiveRecord::Schema.define(version: 20240311081254) do
     t.string "picture"
     t.index ["user_id", "created_at"], name: "index_microposts_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_microposts_on_user_id"
+  end
+
+  create_table "relationships", force: :cascade do |t|
+    t.integer "follower_id"
+    t.integer "followed_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["followed_id"], name: "index_relationships_on_followed_id"
+    t.index ["follower_id", "followed_id"], name: "index_relationships_on_follower_id_and_followed_id", unique: true
+    t.index ["follower_id"], name: "index_relationships_on_follower_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -30,3 +30,10 @@ users = User.order(:created_at).take(6)
   content = Faker::Lorem.sentence(5)
   users.each { |user| user.microposts.create!(content: content) }
 end
+
+users = User.all
+user  = users.first
+following = users[2..50]
+followers = users[3..40]
+following.each { |followed| user.follow(followed) }
+followers.each { |follower| follower.follow(user) }

--- a/test/controllers/relationships_controller_test.rb
+++ b/test/controllers/relationships_controller_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class RelationshipsControllerTest < ActionDispatch::IntegrationTest
+
+  test "create should require logged-in user" do
+    assert_no_difference 'Relationship.count' do
+      post relationships_path
+    end
+    assert_redirected_to login_url
+  end
+
+  test "destroy should require logged-in user" do
+    assert_no_difference 'Relationship.count' do
+      delete relationship_path(relationships(:one))
+    end
+    assert_redirected_to login_url
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -58,4 +58,14 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     end
     assert_redirected_to root_url
   end
+
+  test "should redirect following when not logged in" do
+    get following_user_path(@user)
+    assert_redirected_to login_url
+  end
+
+  test "should redirect followers when not logged in" do
+    get followers_user_path(@user)
+    assert_redirected_to login_url
+  end
 end

--- a/test/fixtures/relationships.yml
+++ b/test/fixtures/relationships.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  follower_id: 1
+  followed_id: 1
+
+two:
+  follower_id: 1
+  followed_id: 1

--- a/test/fixtures/relationships.yml
+++ b/test/fixtures/relationships.yml
@@ -1,1 +1,15 @@
-# Nothing for now
+one:
+  follower: kedar
+  followed: user_1
+
+two:
+  follower: kedar
+  followed: user_2
+
+three:
+  follower: user_1
+  followed: kedar
+
+four:
+  follower: lando
+  followed: kedar

--- a/test/fixtures/relationships.yml
+++ b/test/fixtures/relationships.yml
@@ -1,9 +1,1 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-one:
-  follower_id: 1
-  followed_id: 1
-
-two:
-  follower_id: 1
-  followed_id: 1
+# Nothing for now

--- a/test/integration/following_test.rb
+++ b/test/integration/following_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class FollowingTest < ActionDispatch::IntegrationTest
+
+  def setup
+    @user = users(:kedar)
+    log_in_as(@user)
+  end
+
+  test "following page" do
+    get following_user_path(@user)
+    assert_not @user.following.empty?
+    assert_match @user.following.count.to_s, response.body
+    @user.following.each do |user|
+      assert_select "a[href=?]", user_path(user)
+    end
+  end
+
+  test "followers page" do
+    get followers_user_path(@user)
+    assert_not @user.followers.empty?
+    assert_match @user.followers.count.to_s, response.body
+    @user.followers.each do |user|
+      assert_select "a[href=?]", user_path(user)
+    end
+  end
+end

--- a/test/integration/following_test.rb
+++ b/test/integration/following_test.rb
@@ -4,6 +4,7 @@ class FollowingTest < ActionDispatch::IntegrationTest
 
   def setup
     @user = users(:kedar)
+    @other = users(:lando)
     log_in_as(@user)
   end
 
@@ -22,6 +23,34 @@ class FollowingTest < ActionDispatch::IntegrationTest
     assert_match @user.followers.count.to_s, response.body
     @user.followers.each do |user|
       assert_select "a[href=?]", user_path(user)
+    end
+  end
+  
+  test "should follow a user the standard way" do
+    assert_difference '@user.following.count', 1 do
+      post relationships_path, params: { followed_id: @other.id }
+    end
+  end
+
+  test "should follow a user with Ajax" do
+    assert_difference '@user.following.count', 1 do
+      post relationships_path, xhr: true, params: { followed_id: @other.id }
+    end
+  end
+
+  test "should unfollow a user the standard way" do
+    @user.follow(@other)
+    relationship = @user.active_relationships.find_by(followed_id: @other.id)
+    assert_difference '@user.following.count', -1 do
+      delete relationship_path(relationship)
+    end
+  end
+
+  test "should unfollow a user with Ajax" do
+    @user.follow(@other)
+    relationship = @user.active_relationships.find_by(followed_id: @other.id)
+    assert_difference '@user.following.count', -1 do
+      delete relationship_path(relationship), xhr: true
     end
   end
 end

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class RelationshipTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -1,7 +1,23 @@
 require 'test_helper'
 
 class RelationshipTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+
+  def setup
+    @relationship = Relationship.new(follower_id: users(:kedar).id,
+                                     followed_id: users(:lando).id)
+  end
+
+  test "should be valid" do
+    assert @relationship.valid?
+  end
+
+  test "should require a follower_id" do
+    @relationship.follower_id = nil
+    assert_not @relationship.valid?
+  end
+
+  test "should require a followed_id" do
+    @relationship.followed_id = nil
+    assert_not @relationship.valid?
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -69,4 +69,14 @@ class UserTest < ActiveSupport::TestCase
       @user.destroy
     end
   end
+  test "should follow and unfollow a user" do
+    kedar = users(:kedar)
+    lando  = users(:lando)
+    assert_not kedar.following?(lando)
+    kedar.follow(lando)
+    assert kedar.following?(lando)
+    assert lando.followers.include?(kedar)
+    kedar.unfollow(lando)
+    assert_not kedar.following?(lando)
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -79,4 +79,19 @@ class UserTest < ActiveSupport::TestCase
     kedar.unfollow(lando)
     assert_not kedar.following?(lando)
   end
+
+  test "fedd should have the right posts" do
+    kedar = users(:kedar)
+    user1 = users(:user_1)
+    user2 = users(:user_2)
+    kedar.microposts.each do |post_following|
+      assert kedar.feed.include?(post_following)
+    end
+    user1.microposts.each do |post_following|
+      assert kedar.feed.include?(post_following)
+    end
+    user2.microposts.each do |post_following|
+      assert kedar.feed.include?(post_following)
+    end
+  end
 end


### PR DESCRIPTION
In this PR we have implemented a new feature of Followers and Following.

- We created a new table called relationships and have pairs of user-ids.
    - follower_ids and following_ids.
- Created a stats partial in user page and home (feed) page.
    -  Stats display the follower and following count 
    - When clicked on each of them we get the list of users in the right hand side and gravatar images of the same in the left hand side.
- Finally, we updated the feed to contain IDs of all the users where following id is the logged in user. (Basically get ids of all the users that you are following so that we can get microposts of those users).